### PR TITLE
Support for SingleCellExperiment and all Seurat versions

### DIFF
--- a/R/TemporaObjClass.R
+++ b/R/TemporaObjClass.R
@@ -284,11 +284,20 @@ CreateTemporaObject <- function(exprMatrix, meta.data, timepoint_order, cluster_
 #' Import data from a Seurat object
 #'
 #' Imports gene expression matrix and other metadata from a seurat object
-#' @param seuratobj A Seurat object containing the normalized gene expression matrix and clustering result
+#' @param seuratobj A Seurat or SingleCellExperiment object containing the normalized gene expression matrix and clustering result
+#' @param assayType A length-one character vector representing the assay object
+#'   in which the expression data is stored in the input object. For Seurat v1
+#'   or v2 objects, set this to "". For Seurat v3 objects, this is often "RNA".
+#'   For SingleCellExperiment objects, this is often "logcounts".
+#' @param assaySlot An optional length-one character vector representing the
+#'   slot of the Seurat v3 \code{\link[Seurat]{Assay}} object to use. In Seurat
+#'   v3, normalized data is stored in the "data" slot, and counts in the
+#'   "counts" slot.
 #' @param clusters Name of the column in the meta.data dataframe containing the cluster identity of all cells in the dataset
 #' @param timepoints Name of the column in the meta.data dataframe containing the collection time of all cells in the dataset
 #' @param timepoint_order An ordered vector of timepoint names from early to late
 #' @param cluster_labels A vector of cluster annotations (cell types, cell states, cell cycles, etc.), ordered alphanumerically by cluster names. If NULL, cluster numbers will be used to label the trajectory plot
+#' @include dataAccess.R
 #' @export
 #' @importFrom methods new validObject
 #' @importFrom stats p.adjust prcomp screeplot
@@ -297,15 +306,16 @@ CreateTemporaObject <- function(exprMatrix, meta.data, timepoint_order, cluster_
 #' @examples \dontrun{tempora_data <- ImportSeuratObject(seurat_object, clusters = "res.0.3", timepoints = "collection_time",
 #' timepoint_order = c("0H", "24H", "48H", "72H"), cluster_labels = c("Stem cells", "Differentiated cells"))}
 
-ImportSeuratObject <- function(seuratobj, clusters, timepoints, timepoint_order, cluster_labels){
-  if(class(seuratobj)[1]=='seurat'){
-    requireNamespace("Seurat")
-  } else {
-    stop("Not a Seurat object. Tempora only supports importing Seurat objects at the moment. See ?Tempora::CreateTemporaObject to manually create a Tempora object from an expression matrix")
-  }
-  data <- seuratobj@data
+ImportSeuratObject <- function(seuratobj, assayType = "", assaySlot = NA,
+                               clusters, timepoints, timepoint_order, cluster_labels){
+  # if(class(seuratobj)[1]=='seurat'){
+  #   requireNamespace("Seurat")
+  # } else {
+  #   stop("Not a Seurat object. Tempora only supports importing Seurat objects at the moment. See ?Tempora::CreateTemporaObject to manually create a Tempora object from an expression matrix")
+  # }
+  data <- getExpr(seuratobj,assayType,assaySlot)
   cat("Extracting data...")
-  metadata <- seuratobj@meta.data
+  metadata <- getMD(seuratobj)
   cat("\nExtracting metadata...")
   colnames(metadata)[which(colnames(metadata)==clusters)] <- "Clusters"
   colnames(metadata)[which(colnames(metadata)==timepoints)] <- "Timepoints"

--- a/R/TemporaObjClass.R
+++ b/R/TemporaObjClass.R
@@ -314,6 +314,14 @@ ImportSeuratObject <- function(seuratobj, assayType = "", assaySlot = NA,
   #   stop("Not a Seurat object. Tempora only supports importing Seurat objects at the moment. See ?Tempora::CreateTemporaObject to manually create a Tempora object from an expression matrix")
   # }
   data <- getExpr(seuratobj,assayType,assaySlot)
+  if (! is.numeric(data)) {
+    data <- as.matrix(data)
+    # often Seurat / SingleCellExperiment data matrices are stored as sparse
+    # Matrix::dgCMatrix objects. Since the S4 class requires this object to be
+    # numeric, we must convert them to traditional numeric R matrices, despite
+    # the increased memory costs this entails. Or allow sparse matrices in the
+    # S4 class, but that would involve some further debugging...
+  }
   cat("Extracting data...")
   metadata <- getMD(seuratobj)
   cat("\nExtracting metadata...")

--- a/R/dataAccess.R
+++ b/R/dataAccess.R
@@ -1,0 +1,146 @@
+# Generics & methods for loading data from various single-cell data classes.
+
+# Generics ----
+
+# ^ getExpr ----
+
+#' Get gene expression matrix from input data object
+#'
+#' Extract the gene expression matrix from a single-cell data object containing
+#' the input data for scClustViz visualization.
+#'
+#' This is a wrapper function to the relevant class's normalized data slot
+#' accessor method. Currently supported input object classes: \itemize{ \item
+#' Class \code{\link[Seurat]{seurat}/\link[Seurat]{Seurat}} stored in
+#' \code{x@data} or \code{x@assays[[assayType]]@assaySlot}, depending on Seurat
+#' object version. \item Class
+#' \code{\link[SingleCellExperiment]{SingleCellExperiment}} accessed by
+#' \code{\link[SummarizedExperiment]{assay}(x,assayType)}. }
+#' \href{https://github.com/BaderLab/scClustViz/issues}{Please submit requests
+#' for other data objects here!}
+#'
+#' @param x The single-cell data object.
+#' @param assayType A length-one character vector representing the assay object
+#'   in which the expression data is stored in the input object. For Seurat v1
+#'   or v2 objects, set this to "". For Seurat v3 objects, this is often "RNA".
+#'   For SingleCellExperiment objects, this is often "logcounts". See Details
+#'   for how this argument is used in the accessor functions for each class.
+#' @param assaySlot An optional length-one character vector representing the
+#'   slot of the Seurat v3 \code{\link[Seurat]{Assay}} object to use. In Seurat
+#'   v3, normalized data is stored in the "data" slot, and counts in the
+#'   "counts" slot. See Details for how this argument is used in the accessor
+#'   functions for each class.
+#' @name getExpr
+#' @author Contributed by Brendan Innes from the BaderLab/scClustViz package
+#' @export
+#'
+setGeneric("getExpr",function(x,assayType,assaySlot) standardGeneric("getExpr"))
+
+
+# ^ getMD ----
+
+#' Get metadata from input data object
+#'
+#' Extract the cell metadata data frame from a single-cell data object
+#' containing the input data for scClustViz visualization.
+#'
+#' This is a wrapper function to the relevant class's cell metadata slot
+#' accessor / assignment method. Currently supported input object classes:
+#' \itemize{
+#'   \item Class \code{\link[Seurat]{seurat}/\link[Seurat]{Seurat}} accessed by
+#'     \code{x@data.info} or \code{x@meta.data},
+#'     depending on Seurat object version.
+#'   \item Class \code{\link[SingleCellExperiment]{SingleCellExperiment}}
+#'     accessed by \code{\link[SingleCellExperiment]{colData}(x)}.
+#' }
+#' \href{https://github.com/BaderLab/scClustViz/issues}{Please submit requests
+#' for other data objects here!}
+#'
+#' @param x The single-cell data object.
+#' @name getMD
+#' @author Contributed by Brendan Innes from the BaderLab/scClustViz package
+#' @export
+#'
+setGeneric("getMD",function(x) standardGeneric("getMD"))
+
+
+# Methods ----
+
+# ^ seurat (v1/2) ----
+suppressMessages(
+  setMethod("getExpr","seurat",function(x) {
+    slot(x,"data")
+  })
+)
+
+
+suppressMessages(
+  setMethod("getMD","seurat",function(x) {
+    if (.hasSlot(x,"meta.data")) {
+      slot(x,"meta.data")
+    } else {
+      slot(x,"data.info") #Seurat v1
+    }
+  })
+)
+
+
+# ^ Seurat (v3) ----
+suppressMessages(
+  setMethod("getExpr","Seurat",function(x,assayType,assaySlot) {
+    if (missing(assayType)) {
+      stop(paste(paste0("assayType must be specified."),
+                 "The following assay data are available in this object:",
+                 paste0(names(slot(x,"assays")),collapse=", "),sep="\n  "))
+    }
+    if (assayType %in% names(slot(x,"assays"))) {
+      if (!missing(assaySlot)) {
+        if (is.na(assaySlot) | assaySlot == "") {
+          return(x@assays[[assayType]]@data)
+        } else {
+          return(slot(x@assays[[assayType]],assaySlot))
+        }
+      } else {
+        return(x@assays[[assayType]]@data)
+      }
+    } else {
+      stop(paste(paste0("assayType '",assayType,"' not found."),
+                 "The following assay data are available in this object:",
+                 paste0(names(slot(x,"assays")),collapse=", "),sep="\n  "))
+    }
+  })
+)
+
+
+suppressMessages(
+  setMethod("getMD","Seurat",function(x) {
+    return(slot(x,"meta.data"))
+  })
+)
+
+
+# ^ SingleCellExperiment ----
+suppressMessages(
+  setMethod("getExpr","SingleCellExperiment",function(x,assayType) {
+    if (missing(assayType)) {
+      stop(paste(paste0("assayType must be specified."),
+                 "The following assay data are available in this object:",
+                 paste0(SummarizedExperiment::assayNames(x),collapse=", "),
+                 sep="\n  "))
+    }
+    if (assayType %in% SummarizedExperiment::assayNames(x)) {
+      return(SummarizedExperiment::assay(x,assayType))
+    } else {
+      stop(paste(paste0("assayType '",assayType,"' not found."),
+                 "The following assay data are available in this object:",
+                 paste0(SummarizedExperiment::assayNames(x),collapse=", "),
+                 sep="\n  "))
+    }
+  })
+)
+
+
+suppressMessages(
+  setMethod("getMD","SingleCellExperiment",
+            function(x) SingleCellExperiment::colData(x))
+)


### PR DESCRIPTION
Copied data access methods from scClustViz for all Seurat versions and SingleCellExperiment.
Had to force sparse matrices storing expression data to standard R numeric matrices to satisfy type requirements of the Tempora object.