### PR TITLE
Bug with Seurat clusters

### DIFF
--- a/R/BuildTrajectory.R
+++ b/R/BuildTrajectory.R
@@ -37,8 +37,8 @@ BuildTrajectory <- function(object, n_pcs, difference_threshold=0.01){
   edges_df <- as.data.frame(mi_network$arcs)
   edges_df$to <- as.numeric(as.character(edges_df$to))
   edges_df$from <- as.numeric(as.character(edges_df$from))
-  edges_df$from_clusterscore <- unlist(sapply(edges_df$from, function(x) object@cluster.metadata$Cluster_time_score[which(rownames(object@cluster.metadata) == x)]))
-  edges_df$to_clusterscore <- unlist(sapply(edges_df$to, function(x) object@cluster.metadata$Cluster_time_score[which(rownames(object@cluster.metadata) == x)]))
+  edges_df$from_clusterscore <- unlist(sapply(edges_df$from, function(x) object@cluster.metadata$Cluster_time_score[object@cluster.metadata$Id == x]))
+  edges_df$to_clusterscore <- unlist(sapply(edges_df$to, function(x) object@cluster.metadata$Cluster_time_score[object@cluster.metadata$Id == x]))
 
 
   edges_df$direction <- ifelse((abs(edges_df$to_clusterscore - edges_df$from_clusterscore)/(0.5*(edges_df$to_clusterscore + edges_df$from_clusterscore))) < difference_threshold, "bidirectional", "unidirectional")

--- a/R/CalculatePWProfiles.R
+++ b/R/CalculatePWProfiles.R
@@ -28,6 +28,7 @@ CalculatePWProfiles <- function(object, gmt_path, method="gsva", min.sz=5, max.s
   for (i in sort(unique(object@meta.data$Clusters))){
     exprMatrix_bycluster[[i]] <- rowMeans(exprMatrix[, which(colnames(exprMatrix) %in% rownames(object@meta.data)[which(object@meta.data$Clusters == i)])])
   }
+  names(exprMatrix_bycluster) <- sort(unique(seu_tempora@meta.data$Clusters))
 
   exprMatrix_bycluster <- do.call(cbind, exprMatrix_bycluster)
   colnames(exprMatrix_bycluster) <- sort(unique(object@meta.data$Clusters))

--- a/R/CalculatePWProfiles.R
+++ b/R/CalculatePWProfiles.R
@@ -25,12 +25,12 @@ CalculatePWProfiles <- function(object, gmt_path, method="gsva", min.sz=5, max.s
   exprMatrix <- object@data
   exprMatrix_bycluster <- list()
   pathwaygmt <- GSEABase::getGmt(gmt_path)
-  for (i in sort(as.numeric(unique(object@meta.data$Clusters)))){
+  for (i in sort(unique(object@meta.data$Clusters))){
     exprMatrix_bycluster[[i]] <- rowMeans(exprMatrix[, which(colnames(exprMatrix) %in% rownames(object@meta.data)[which(object@meta.data$Clusters == i)])])
   }
 
   exprMatrix_bycluster <- do.call(cbind, exprMatrix_bycluster)
-  colnames(exprMatrix_bycluster) <- sort(as.numeric(unique(object@meta.data$Clusters)))
+  colnames(exprMatrix_bycluster) <- sort(unique(object@meta.data$Clusters))
   rownames(exprMatrix_bycluster) <- rownames(exprMatrix)
 
   cat("\nCalculating cluster pathway enrichment profiles...\n")


### PR DESCRIPTION
Fixed a bug occurring with clusters from Seurat (that start with 0).
Using the row names gives a wrong matching because they start from 1.